### PR TITLE
Configure weekly updates for NuGet packages in DevSweep (add dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/net/src/DevSweep/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "nuget"
-    directory: "/net/tests/DevSweep.Tests/"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request adds a Dependabot configuration file to enable automated dependency updates for the project. The configuration ensures that NuGet dependencies in both the main source and test directories are checked and updated on a weekly schedule.

Dependency management automation:

* Added a `.github/dependabot.yml` file to configure Dependabot for NuGet packages in the `/net/src/DevSweep/` and `/net/tests/DevSweep.Tests/` directories, with weekly update checks.…weep

It is described in the [Issue#54](https://github.com/Sstark97/dev_sweep/issues/54) 