### PR TITLE
feat(tests): migrate tests from Xunit to TUnit framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,11 +5,10 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="DotMake.CommandLine" Version="2.0.0" />
+    <PackageVersion Include="TUnit" Version="1.18.37" />
     <PackageVersion Include="Spectre.Console" Version="0.49.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/net/tests/DevSweep.Tests/Application/Models/AnalysisReportShould.cs
+++ b/net/tests/DevSweep.Tests/Application/Models/AnalysisReportShould.cs
@@ -2,13 +2,12 @@ using AwesomeAssertions;
 using DevSweep.Application.Models;
 using DevSweep.Domain.Enums;
 using DevSweep.Tests.Builders;
-using Xunit;
 
 namespace DevSweep.Tests.Application.Models;
 
-public class AnalysisReportShould
+internal sealed class AnalysisReportShould
 {
-    [Fact]
+    [Test]
     public void SucceedWithValidModuleAnalyses()
     {
         var dockerAnalysis = ModuleAnalysis.CreateEmpty(CleanupModuleName.Docker);
@@ -18,7 +17,7 @@ public class AnalysisReportShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedWithEmptyModuleAnalysesList()
     {
         var result = AnalysisReport.Create([]);
@@ -26,7 +25,7 @@ public class AnalysisReportShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void CalculateTotalSizeAcrossModules()
     {
         var dockerItem = new CleanableItemBuilder()
@@ -52,7 +51,7 @@ public class AnalysisReportShould
         report.TotalSize().Should().Be(dockerItem.Size.Add(homebrewItem.Size));
     }
 
-    [Fact]
+    [Test]
     public void CountTotalItemsAcrossModules()
     {
         var dockerItem = new CleanableItemBuilder()
@@ -81,7 +80,7 @@ public class AnalysisReportShould
         report.TotalItemCount().Should().Be(3);
     }
 
-    [Fact]
+    [Test]
     public void CountModules()
     {
         var dockerAnalysis = ModuleAnalysis.CreateEmpty(CleanupModuleName.Docker);
@@ -94,7 +93,7 @@ public class AnalysisReportShould
         report.ModuleCount().Should().Be(2);
     }
 
-    [Fact]
+    [Test]
     public void ReportEmptyWhenAllModulesEmpty()
     {
         var emptyDockerAnalysis = ModuleAnalysis.CreateEmpty(CleanupModuleName.Docker);
@@ -107,7 +106,7 @@ public class AnalysisReportShould
         report.IsEmpty().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportNotEmptyWhenAnyModuleHasItems()
     {
         var dockerItem = new CleanableItemBuilder()
@@ -126,7 +125,7 @@ public class AnalysisReportShould
         report.IsEmpty().Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void CreateEmptyReport()
     {
         var emptyReport = AnalysisReport.CreateEmpty();
@@ -136,7 +135,7 @@ public class AnalysisReportShould
         emptyReport.TotalItemCount().Should().Be(0);
     }
 
-    [Fact]
+    [Test]
     public void FailWhenModuleAnalysesIsNull()
     {
         var result = AnalysisReport.Create(null);

--- a/net/tests/DevSweep.Tests/Application/Models/CommandOutputShould.cs
+++ b/net/tests/DevSweep.Tests/Application/Models/CommandOutputShould.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Application.Models;
-using Xunit;
 
 namespace DevSweep.Tests.Application.Models;
 
-public class CommandOutputShould
+internal sealed class CommandOutputShould
 {
-    [Fact]
+    [Test]
     public void SucceedWithValidParameters()
     {
         var result = CommandOutput.Create(0, "output text", string.Empty);
@@ -14,7 +13,7 @@ public class CommandOutputShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void FailWhenStandardOutputIsNull()
     {
         var result = CommandOutput.Create(0, null!, string.Empty);
@@ -23,7 +22,7 @@ public class CommandOutputShould
         result.Error.MessageContains("standard output").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void FailWhenStandardErrorIsNull()
     {
         var result = CommandOutput.Create(0, string.Empty, null!);
@@ -32,7 +31,7 @@ public class CommandOutputShould
         result.Error.MessageContains("standard error").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportSuccessfulWhenExitCodeIsZero()
     {
         var outputResult = CommandOutput.Create(0, "done", string.Empty);
@@ -42,7 +41,7 @@ public class CommandOutputShould
         output.IsSuccessful().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportUnsuccessfulWhenExitCodeIsNonZero()
     {
         var outputResult = CommandOutput.Create(1, string.Empty, "error occurred");
@@ -52,7 +51,7 @@ public class CommandOutputShould
         output.IsSuccessful().Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void ReportHasOutputWhenStandardOutputIsNotEmpty()
     {
         var outputResult = CommandOutput.Create(0, "some output", string.Empty);
@@ -62,7 +61,7 @@ public class CommandOutputShould
         output.HasOutput().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportNoOutputWhenStandardOutputIsEmpty()
     {
         var outputResult = CommandOutput.Create(0, string.Empty, string.Empty);
@@ -72,7 +71,7 @@ public class CommandOutputShould
         output.HasOutput().Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void CreateFailedCommandOutput()
     {
         var result = CommandOutput.CreateFailed("command not found");

--- a/net/tests/DevSweep.Tests/Application/Models/ModuleAnalysisShould.cs
+++ b/net/tests/DevSweep.Tests/Application/Models/ModuleAnalysisShould.cs
@@ -2,13 +2,12 @@ using AwesomeAssertions;
 using DevSweep.Application.Models;
 using DevSweep.Domain.Enums;
 using DevSweep.Tests.Builders;
-using Xunit;
 
 namespace DevSweep.Tests.Application.Models;
 
-public class ModuleAnalysisShould
+internal sealed class ModuleAnalysisShould
 {
-    [Fact]
+    [Test]
     public void SucceedWithValidItems()
     {
         var dockerItem = new CleanableItemBuilder()
@@ -22,7 +21,7 @@ public class ModuleAnalysisShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedWithEmptyItemsList()
     {
         var result = ModuleAnalysis.Create(CleanupModuleName.Docker, []);
@@ -30,7 +29,7 @@ public class ModuleAnalysisShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void CalculateTotalSizeFromAllItems()
     {
         var firstItem = new CleanableItemBuilder()
@@ -53,7 +52,7 @@ public class ModuleAnalysisShould
         analysis.TotalSize().Should().Be(firstItem.Size.Add(secondItem.Size));
     }
 
-    [Fact]
+    [Test]
     public void CountSafeItems()
     {
         var safeItem = new CleanableItemBuilder()
@@ -79,7 +78,7 @@ public class ModuleAnalysisShould
         analysis.SafeItemCount().Should().Be(2);
     }
 
-    [Fact]
+    [Test]
     public void CountUnsafeItems()
     {
         var safeItem = new CleanableItemBuilder()
@@ -100,7 +99,7 @@ public class ModuleAnalysisShould
         analysis.UnsafeItemCount().Should().Be(1);
     }
 
-    [Fact]
+    [Test]
     public void CountTotalItems()
     {
         var safeItem = new CleanableItemBuilder()
@@ -121,7 +120,7 @@ public class ModuleAnalysisShould
         analysis.ItemCount().Should().Be(2);
     }
 
-    [Fact]
+    [Test]
     public void ReportEmptyWhenNoItems()
     {
         var analysisResult = ModuleAnalysis.Create(CleanupModuleName.Docker, []);
@@ -131,7 +130,7 @@ public class ModuleAnalysisShould
         analysis.IsEmpty().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportNotEmptyWhenHasItems()
     {
         var dockerItem = new CleanableItemBuilder()
@@ -147,7 +146,7 @@ public class ModuleAnalysisShould
         analysis.IsEmpty().Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void CreateEmptyAnalysis()
     {
         var emptyAnalysis = ModuleAnalysis.CreateEmpty(CleanupModuleName.Docker);
@@ -156,7 +155,7 @@ public class ModuleAnalysisShould
         emptyAnalysis.Module.Should().Be(CleanupModuleName.Docker);
     }
 
-    [Fact]
+    [Test]
     public void FailWhenItemsIsNull()
     {
         var result = ModuleAnalysis.Create(CleanupModuleName.Docker, null);

--- a/net/tests/DevSweep.Tests/Application/Models/ModuleDescriptorShould.cs
+++ b/net/tests/DevSweep.Tests/Application/Models/ModuleDescriptorShould.cs
@@ -1,13 +1,12 @@
 using AwesomeAssertions;
 using DevSweep.Application.Models;
 using DevSweep.Domain.Enums;
-using Xunit;
 
 namespace DevSweep.Tests.Application.Models;
 
-public class ModuleDescriptorShould
+internal sealed class ModuleDescriptorShould
 {
-    [Fact]
+    [Test]
     public void SucceedWithValidParameters()
     {
         var result = ModuleDescriptor.Create(CleanupModuleName.Docker, "Cleans Docker caches", false);
@@ -15,9 +14,9 @@ public class ModuleDescriptorShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
+    [Test]
+    [Arguments("")]
+    [Arguments("   ")]
     public void FailWhenDescriptionIsMissingOrEmpty(string description)
     {
         var result = ModuleDescriptor.Create(CleanupModuleName.Docker, description, false);
@@ -26,7 +25,7 @@ public class ModuleDescriptorShould
         result.Error.IsValidationError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportDestructiveWhenMarkedAsDestructive()
     {
         var descriptorResult = ModuleDescriptor.Create(CleanupModuleName.Docker, "Cleans Docker caches", true);
@@ -36,7 +35,7 @@ public class ModuleDescriptorShould
         descriptor.IsDestructive().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReportNonDestructiveWhenNotMarkedAsDestructive()
     {
         var descriptorResult = ModuleDescriptor.Create(CleanupModuleName.Homebrew, "Cleans Homebrew caches", false);

--- a/net/tests/DevSweep.Tests/Application/Modules/ModuleRegistryShould.cs
+++ b/net/tests/DevSweep.Tests/Application/Modules/ModuleRegistryShould.cs
@@ -1,16 +1,13 @@
 using AwesomeAssertions;
 using DevSweep.Application.Modules;
-using DevSweep.Domain.Common;
 using DevSweep.Domain.Enums;
-using DevSweep.Domain.Errors;
 using NSubstitute;
-using Xunit;
 
 namespace DevSweep.Tests.Application.Modules;
 
-public class ModuleRegistryShould
+internal sealed class ModuleRegistryShould
 {
-    [Fact]
+    [Test]
     public void RegisterModule()
     {
         var registry = new ModuleRegistry();
@@ -25,7 +22,7 @@ public class ModuleRegistryShould
         registeredModule.Should().BeSameAs(dockerModule);
     }
 
-    [Fact]
+    [Test]
     public void FailWhenModuleNotRegistered()
     {
         var registry = new ModuleRegistry();
@@ -36,7 +33,7 @@ public class ModuleRegistryShould
         result.Error.IsNotFoundError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReturnAllRegisteredModules()
     {
         var registry = new ModuleRegistry();
@@ -55,7 +52,7 @@ public class ModuleRegistryShould
         modules.Should().Contain(homebrewModule);
     }
 
-    [Fact]
+    [Test]
     public void ReturnEmptyListWhenNoModulesRegistered()
     {
         var registry = new ModuleRegistry();
@@ -65,7 +62,7 @@ public class ModuleRegistryShould
         modules.Should().BeEmpty();
     }
 
-    [Fact]
+    [Test]
     public void OverwriteModuleWithSameName()
     {
         var registry = new ModuleRegistry();
@@ -85,7 +82,7 @@ public class ModuleRegistryShould
         registry.Modules().Should().HaveCount(1);
     }
 
-    [Fact]
+    [Test]
     public void FailWhenRegisteringNullModule()
     {
         var registry = new ModuleRegistry();

--- a/net/tests/DevSweep.Tests/DevSweep.Tests.csproj
+++ b/net/tests/DevSweep.Tests/DevSweep.Tests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="coverlet.collector" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" PrivateAssets="all" />
-    <PackageReference Include="xunit.runner.visualstudio" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" PrivateAssets="all" />
+    <PackageReference Include="TUnit" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="AwesomeAssertions" />
   </ItemGroup>

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultBindTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultBindTests.cs
@@ -1,13 +1,12 @@
 using System.Globalization;
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultBindTests
+internal sealed class ResultBindTests
 {
-    [Fact]
+    [Test]
     public void ChainsSuccessfulOperations()
     {
         var result = Result<int, string>.Success(5);
@@ -18,7 +17,7 @@ public class ResultBindTests
         bound.Value.Should().Be(10);
     }
 
-    [Fact]
+    [Test]
     public void PropagatesFirstErrorInChain()
     {
         var result = Result<int, string>.Failure("first error");
@@ -29,7 +28,7 @@ public class ResultBindTests
         bound.Error.Should().Be("first error");
     }
 
-    [Fact]
+    [Test]
     public void AllowsNestedBindOperations()
     {
         var result = Result<int, string>.Success(5);

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultFailureTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultFailureTests.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultFailureTests
+internal sealed class ResultFailureTests
 {
-    [Fact]
+    [Test]
     public void IsFailureReturnsTrueForFailureResult()
     {
         var result = Result<int, string>.Failure("error");
@@ -14,7 +13,7 @@ public class ResultFailureTests
         result.IsFailure.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsSuccessReturnsFalseForFailureResult()
     {
         var result = Result<int, string>.Failure("error");
@@ -22,7 +21,7 @@ public class ResultFailureTests
         result.IsSuccess.Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void ErrorReturnsCorrectErrorForFailureResult()
     {
         var result = Result<int, string>.Failure("error message");
@@ -30,7 +29,7 @@ public class ResultFailureTests
         result.Error.Should().Be("error message");
     }
 
-    [Fact]
+    [Test]
     public void ValueThrowsExceptionForFailureResult()
     {
         var result = Result<int, string>.Failure("error");

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultLinqQuerySyntaxTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultLinqQuerySyntaxTests.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultLinqQuerySyntaxTests
+internal sealed class ResultLinqQuerySyntaxTests
 {
-    [Fact]
+    [Test]
     public void TransformsValueUsingSelectSyntax()
     {
         var result =
@@ -17,7 +16,7 @@ public class ResultLinqQuerySyntaxTests
         result.Value.Should().Be(10);
     }
 
-    [Fact]
+    [Test]
     public void ComposesMultipleOperationsUsingQuerySyntax()
     {
         var result =
@@ -29,7 +28,7 @@ public class ResultLinqQuerySyntaxTests
         result.Value.Should().Be(15);
     }
 
-    [Fact]
+    [Test]
     public void PropagatesFirstErrorInQueryChain()
     {
         var result =
@@ -41,7 +40,7 @@ public class ResultLinqQuerySyntaxTests
         result.Error.Should().Be("first error");
     }
 
-    [Fact]
+    [Test]
     public void AllowsComplexRailwayOrientedComposition()
     {
         var result =

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultMapTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultMapTests.cs
@@ -1,13 +1,12 @@
 using System.Globalization;
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultMapTests
+internal sealed class ResultMapTests
 {
-    [Fact]
+    [Test]
     public void TransformsValueWhenResultIsSuccess()
     {
         var result = Result<int, string>.Success(5);
@@ -18,7 +17,7 @@ public class ResultMapTests
         mapped.Value.Should().Be(10);
     }
 
-    [Fact]
+    [Test]
     public void PropagatesErrorWhenResultIsFailure()
     {
         var result = Result<int, string>.Failure("error");
@@ -29,7 +28,7 @@ public class ResultMapTests
         mapped.Error.Should().Be("error");
     }
 
-    [Fact]
+    [Test]
     public void AllowsChainingMultipleMapOperations()
     {
         var result = Result<int, string>.Success(5);

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultMatchTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultMatchTests.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultMatchTests
+internal sealed class ResultMatchTests
 {
-    [Fact]
+    [Test]
     public void ExecutesSuccessFunctionWhenResultIsSuccess()
     {
         var result = Result<int, string>.Success(42);
@@ -19,7 +18,7 @@ public class ResultMatchTests
         wasCalled.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ExecutesFailureFunctionWhenResultIsFailure()
     {
         var result = Result<int, string>.Failure("error");
@@ -32,7 +31,7 @@ public class ResultMatchTests
         wasCalled.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ReturnsCorrectValueFromMatchFunction()
     {
         var successResult = Result<int, string>.Success(42);

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultSuccessTests.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultSuccessTests.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Common;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Common;
 
-public class ResultSuccessTests
+internal sealed class ResultSuccessTests
 {
-    [Fact]
+    [Test]
     public void IsSuccessReturnsTrueForSuccessResult()
     {
         var result = Result<int, string>.Success(42);
@@ -14,7 +13,7 @@ public class ResultSuccessTests
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IsFailureReturnsFalseForSuccessResult()
     {
         var result = Result<int, string>.Success(42);
@@ -22,7 +21,7 @@ public class ResultSuccessTests
         result.IsFailure.Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void ValueReturnsCorrectValueForSuccessResult()
     {
         var result = Result<int, string>.Success(42);
@@ -30,7 +29,7 @@ public class ResultSuccessTests
         result.Value.Should().Be(42);
     }
 
-    [Fact]
+    [Test]
     public void ErrorThrowsExceptionForSuccessResult()
     {
         var result = Result<int, string>.Success(42);

--- a/net/tests/DevSweep.Tests/Domain/Entities/CleanableItemShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Entities/CleanableItemShould.cs
@@ -1,13 +1,12 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Enums;
 using DevSweep.Tests.Builders;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Entities;
 
-public class CleanableItemShould
+internal sealed class CleanableItemShould
 {
-    [Fact]
+    [Test]
     public void CreateSafeItemWithReason()
     {
         var safeItem = new CleanableItemBuilder()
@@ -20,7 +19,7 @@ public class CleanableItemShould
         safeItem.Reason.Should().Be("Project dependencies");
     }
 
-    [Fact]
+    [Test]
     public void CreateUnsafeItemWithReason()
     {
         var unsafeItem = new CleanableItemBuilder()
@@ -33,7 +32,7 @@ public class CleanableItemShould
         unsafeItem.Reason.Should().Be("Currently in use");
     }
 
-    [Fact]
+    [Test]
     public void FailToMarkForDeletionWhenNotSafe()
     {
         var unsafeItem = new CleanableItemBuilder()
@@ -48,7 +47,7 @@ public class CleanableItemShould
         result.Error.IsInvalidOperationError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedToMarkForDeletionWhenSafe()
     {
         var safeItem = new CleanableItemBuilder()
@@ -62,7 +61,7 @@ public class CleanableItemShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void FailToMarkAsUnsafeWhenAlreadyUnsafe()
     {
         var unsafeItem = new CleanableItemBuilder()
@@ -77,7 +76,7 @@ public class CleanableItemShould
         result.Error.IsInvalidOperationError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedToMarkAsUnsafeWhenSafe()
     {
         var safeItem = new CleanableItemBuilder()
@@ -94,7 +93,7 @@ public class CleanableItemShould
         updatedItem.Reason.Should().Be("Found in active container");
     }
 
-    [Fact]
+    [Test]
     public void FailToMarkAsSafeWhenAlreadySafe()
     {
         var safeItem = new CleanableItemBuilder()
@@ -109,7 +108,7 @@ public class CleanableItemShould
         result.Error.IsInvalidOperationError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedToMarkAsSafeWhenUnsafe()
     {
         var unsafeItem = new CleanableItemBuilder()
@@ -126,7 +125,7 @@ public class CleanableItemShould
         updatedItem.Reason.Should().Be("Container stopped");
     }
 
-    [Fact]
+    [Test]
     public void PreservePathWhenMarkingAsSafe()
     {
         var unsafeItem = new CleanableItemBuilder()
@@ -140,7 +139,7 @@ public class CleanableItemShould
         result.Value.Path.Should().Be(expectedPath);
     }
 
-    [Fact]
+    [Test]
     public void PreserveSizeWhenMarkingAsUnsafe()
     {
         var safeItem = new CleanableItemBuilder()
@@ -154,7 +153,7 @@ public class CleanableItemShould
         result.Value.Size.Should().Be(expectedSize);
     }
 
-    [Fact]
+    [Test]
     public void PreserveModuleTypeWhenChangingSafety()
     {
         var safeItem = new CleanableItemBuilder()

--- a/net/tests/DevSweep.Tests/Domain/Entities/CleanupSummaryShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Entities/CleanupSummaryShould.cs
@@ -1,15 +1,13 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Entities;
 using DevSweep.Domain.Enums;
-using DevSweep.Domain.ValueObjects;
 using DevSweep.Tests.Builders;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Entities;
 
-public class CleanupSummaryShould
+internal sealed class CleanupSummaryShould
 {
-    [Fact]
+    [Test]
     public void FailWhenItemsListIsEmpty()
     {
         var emptyItems = new List<CleanableItem>();
@@ -23,7 +21,7 @@ public class CleanupSummaryShould
         result.Error.IsInvalidOperationError().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedWithValidItems()
     {
         var safeItem = new CleanableItemBuilder()
@@ -41,7 +39,7 @@ public class CleanupSummaryShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void CountTotalItemsScanned()
     {
         var firstItem = new CleanableItemBuilder()
@@ -71,7 +69,7 @@ public class CleanupSummaryShould
         summary.TotalItemsScanned.Should().Be(3);
     }
 
-    [Fact]
+    [Test]
     public void CountOnlySafeItems()
     {
         var safeItem = new CleanableItemBuilder()
@@ -101,7 +99,7 @@ public class CleanupSummaryShould
         summary.SafeItemsFound.Should().Be(2);
     }
 
-    [Fact]
+    [Test]
     public void CountZeroSafeItemsWhenAllUnsafe()
     {
         var firstUnsafeItem = new CleanableItemBuilder()
@@ -126,7 +124,7 @@ public class CleanupSummaryShould
         summary.SafeItemsFound.Should().Be(0);
     }
 
-    [Fact]
+    [Test]
     public void PreserveCleanupResult()
     {
         var safeItem = new CleanableItemBuilder()
@@ -146,7 +144,7 @@ public class CleanupSummaryShould
         summary.Result.Should().Be(originalCleanupResult);
     }
 
-    [Fact]
+    [Test]
     public void PreserveModuleName()
     {
         var safeItem = new CleanableItemBuilder()
@@ -166,7 +164,7 @@ public class CleanupSummaryShould
         summary.Module.Should().Be(CleanupModuleName.Projects);
     }
 
-    [Fact]
+    [Test]
     public void FailWhenItemsIsNull()
     {
         var result = CleanupSummary.Create(

--- a/net/tests/DevSweep.Tests/Domain/Errors/DomainErrorShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Errors/DomainErrorShould.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.Errors;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.Errors;
 
-public class DomainErrorShould
+internal sealed class DomainErrorShould
 {
-    [Fact]
+    [Test]
     public void CreateValidationError()
     {
         var error = DomainError.Validation("Invalid input");
@@ -15,7 +14,7 @@ public class DomainErrorShould
         error.MessageContains("Invalid input").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void CreateNotFoundError()
     {
         var error = DomainError.NotFound("User", "123");
@@ -25,7 +24,7 @@ public class DomainErrorShould
         error.MessageContains("123").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void CreateInvalidOperationError()
     {
         var error = DomainError.InvalidOperation("Cannot perform this action");
@@ -34,7 +33,7 @@ public class DomainErrorShould
         error.MessageContains("Cannot perform").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void FormatErrorWithCodeAndMessage()
     {
         var error = DomainError.Validation("Test message");

--- a/net/tests/DevSweep.Tests/Domain/ValueObjects/CleanupResultShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/ValueObjects/CleanupResultShould.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.ValueObjects;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.ValueObjects;
 
-public class CleanupResultShould
+internal sealed class CleanupResultShould
 {
-    [Fact]
+    [Test]
     public void FailWhenFilesDeletedIsNegative()
     {
         var zeroSize = FileSize.Create(0).Value;
@@ -17,9 +16,9 @@ public class CleanupResultShould
         result.Error.MessageContains("negative").Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(5)]
+    [Test]
+    [Arguments(0)]
+    [Arguments(5)]
     public void SucceedWhenFilesDeletedIsNonNegative(int filesDeleted)
     {
         var validSize = FileSize.Create(1024).Value;
@@ -29,7 +28,7 @@ public class CleanupResultShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IndicateWhenErrorsExist()
     {
         var zeroSize = FileSize.Create(0).Value;
@@ -42,7 +41,7 @@ public class CleanupResultShould
         cleanupResult.HasErrors().Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void IndicateWhenNoErrorsExist()
     {
         var zeroSize = FileSize.Create(0).Value;
@@ -54,7 +53,7 @@ public class CleanupResultShould
         cleanupResult.HasErrors().Should().BeFalse();
     }
 
-    [Fact]
+    [Test]
     public void ProvideTotalFilesDeleted()
     {
         var expectedFileCount = 10;
@@ -68,7 +67,7 @@ public class CleanupResultShould
         combined.TotalFilesDeleted().Should().Be(expectedFileCount + 5);
     }
 
-    [Fact]
+    [Test]
     public void ProvideTotalSpaceFreed()
     {
         var smallSize = FileSize.Create(1024).Value;
@@ -81,7 +80,7 @@ public class CleanupResultShould
         combined.TotalSpaceFreed().Should().Be(smallSize.Add(largeSize));
     }
 
-    [Fact]
+    [Test]
     public void ProvideErrorMessages()
     {
         var zeroSize = FileSize.Create(0).Value;
@@ -99,7 +98,7 @@ public class CleanupResultShould
         actualErrors.Should().Contain(secondError);
     }
 
-    [Fact]
+    [Test]
     public void CombineTwoResults()
     {
         var smallSize = FileSize.Create(1024).Value;
@@ -113,7 +112,7 @@ public class CleanupResultShould
         combined.TotalSpaceFreed().Should().Be(smallSize.Add(largeSize));
     }
 
-    [Fact]
+    [Test]
     public void AggregateMultipleResultsUsingLinq()
     {
         var smallSize = FileSize.Create(1024).Value;
@@ -135,7 +134,7 @@ public class CleanupResultShould
         aggregated.TotalSpaceFreed().Should().Be(smallSize.Add(mediumSize).Add(largeSize));
     }
 
-    [Fact]
+    [Test]
     public void CombineResultsWithErrors()
     {
         var zeroSize = FileSize.Create(0).Value;

--- a/net/tests/DevSweep.Tests/Domain/ValueObjects/FilePathCreationShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/ValueObjects/FilePathCreationShould.cs
@@ -1,15 +1,14 @@
 using AwesomeAssertions;
 using DevSweep.Domain.ValueObjects;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.ValueObjects;
 
-public class FilePathCreationShould
+internal sealed class FilePathCreationShould
 {
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
     public void FailWhenPathIsMissingOrEmpty(string? invalidPath)
     {
         var result = FilePath.Create(invalidPath!);
@@ -19,7 +18,7 @@ public class FilePathCreationShould
         result.Error.MessageContains("empty").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void FailWhenPathExceedsMaximumLength()
     {
         var longPath = new string('a', 261);
@@ -30,7 +29,7 @@ public class FilePathCreationShould
         result.Error.MessageContains("exceeds maximum length").Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void SucceedWhenPathIsValid()
     {
         var path = Path.Combine("valid", "path", "file.txt");
@@ -39,7 +38,7 @@ public class FilePathCreationShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void PreserveOriginalPathValue()
     {
         var originalPath = Path.Combine("documents", "report.pdf");
@@ -50,7 +49,7 @@ public class FilePathCreationShould
         filePath.ToString().Should().Be(originalPath);
     }
 
-    [Fact]
+    [Test]
     public void ExtractFileNameCorrectly()
     {
         var path = Path.Combine("path", "to", "file.txt");
@@ -61,7 +60,7 @@ public class FilePathCreationShould
         filePath.FileName().Should().Be("file.txt");
     }
 
-    [Fact]
+    [Test]
     public void ExtractDirectoryPathCorrectly()
     {
         var path = Path.Combine("path", "to", "file.txt");
@@ -73,7 +72,7 @@ public class FilePathCreationShould
         filePath.DirectoryPath().Should().Be(expectedDirectoryPath);
     }
 
-    [Fact]
+    [Test]
     public void ExtractExtensionCorrectly()
     {
         var path = Path.Combine("path", "to", "file.txt");
@@ -84,7 +83,7 @@ public class FilePathCreationShould
         filePath.Extension().Should().Be(".txt");
     }
 
-    [Fact]
+    [Test]
     public void SupportValueEqualitySemantics()
     {
         var firstValue = FilePath.Create(Path.Combine("path","to", "file.txt")).Value;

--- a/net/tests/DevSweep.Tests/Domain/ValueObjects/FileSizeShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/ValueObjects/FileSizeShould.cs
@@ -1,12 +1,11 @@
 using AwesomeAssertions;
 using DevSweep.Domain.ValueObjects;
-using Xunit;
 
 namespace DevSweep.Tests.Domain.ValueObjects;
 
-public class FileSizeShould
+internal sealed class FileSizeShould
 {
-    [Fact]
+    [Test]
     public void FailWhenBytesAreNegative()
     {
         var result = FileSize.Create(-1);
@@ -16,9 +15,9 @@ public class FileSizeShould
         result.Error.MessageContains("negative").Should().BeTrue();
     }
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(1024)]
+    [Test]
+    [Arguments(0)]
+    [Arguments(1024)]
     public void SucceedWhenBytesAreNonNegative(long bytes)
     {
         var result = FileSize.Create(bytes);
@@ -26,7 +25,7 @@ public class FileSizeShould
         result.IsSuccess.Should().BeTrue();
     }
 
-    [Fact]
+    [Test]
     public void ConvertBytesToKilobytes()
     {
         var result = FileSize.Create(2048);
@@ -36,7 +35,7 @@ public class FileSizeShould
         fileSize.InKilobytes().Should().Be(2m);
     }
 
-    [Fact]
+    [Test]
     public void ConvertBytesToMegabytes()
     {
         var result = FileSize.Create(1048576);
@@ -46,7 +45,7 @@ public class FileSizeShould
         fileSize.InMegabytes().Should().Be(1m);
     }
 
-    [Fact]
+    [Test]
     public void ConvertBytesToGigabytes()
     {
         var result = FileSize.Create(1073741824);
@@ -56,7 +55,7 @@ public class FileSizeShould
         fileSize.InGigabytes().Should().Be(1m);
     }
 
-    [Fact]
+    [Test]
     public void AddTwoSizes()
     {
         var smallSize = FileSize.Create(1024).Value;
@@ -67,11 +66,11 @@ public class FileSizeShould
         sum.InKilobytes().Should().Be(3m);
     }
 
-    [Theory]
-    [InlineData(512, "512 B")]
-    [InlineData(2048, "2.00 KB")]
-    [InlineData(2097152, "2.00 MB")]
-    [InlineData(2147483648, "2.00 GB")]
+    [Test]
+    [Arguments(512, "512 B")]
+    [Arguments(2048, "2.00 KB")]
+    [Arguments(2097152, "2.00 MB")]
+    [Arguments(2147483648, "2.00 GB")]
     public void FormatWithAppropriateSuffix(long bytes, string expected)
     {
         var fileSize = FileSize.Create(bytes).Value;
@@ -79,7 +78,7 @@ public class FileSizeShould
         fileSize.ToString().Should().Be(expected);
     }
 
-    [Fact]
+    [Test]
     public void IndicateSmallerSizeIsLess()
     {
         var small = FileSize.Create(1024).Value;
@@ -89,7 +88,7 @@ public class FileSizeShould
         small.Should().BeLessThan(large);
     }
 
-    [Fact]
+    [Test]
     public void CompareUsingCompareTo()
     {
         var small = FileSize.Create(1024).Value;

--- a/net/tests/DevSweep.Tests/packages.lock.json
+++ b/net/tests/DevSweep.Tests/packages.lock.json
@@ -8,22 +8,6 @@
         "resolved": "9.3.0",
         "contentHash": "8lGLYap2ec2gNLgjf2xKZaKLpQ7j36oJvrYzBVVpNAumqnxRdevqqhEF66qxE92f8y2+zsbQ061DeHG61ZhzaQ=="
       },
-      "coverlet.collector": {
-        "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "bJShQ6uWRTQ100ZeyiMqcFlhP7WJ+bCuabUs885dJiBEzMsJMSFr7BOyeCw4rgvQokteGi5rKQTlkhfQPUXg2A=="
-      },
-      "Microsoft.NET.Test.Sdk": {
-        "type": "Direct",
-        "requested": "[17.12.0, )",
-        "resolved": "17.12.0",
-        "contentHash": "kt/PKBZ91rFCWxVIJZSgVLk+YR+4KxTuHf799ho8WNiK5ZQpJNAEZCAWX86vcKrs+DiYjiibpYKdGZP6+/N17w==",
-        "dependencies": {
-          "Microsoft.CodeCoverage": "17.12.0",
-          "Microsoft.TestPlatform.TestHost": "17.12.0"
-        }
-      },
       "NSubstitute": {
         "type": "Direct",
         "requested": "[5.3.0, )",
@@ -33,22 +17,18 @@
           "Castle.Core": "5.1.1"
         }
       },
-      "xUnit": {
+      "TUnit": {
         "type": "Direct",
-        "requested": "[2.9.3, )",
-        "resolved": "2.9.3",
-        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "requested": "[1.18.37, )",
+        "resolved": "1.18.37",
+        "contentHash": "jvLqWj60BZ/KJbjWnFScKlRJ5dHndLo6+NIxMPe16qViGGcWdGCRCx19LjjWWP9LEYNoRpX+3jG47r/kQYU3KA==",
         "dependencies": {
-          "xunit.analyzers": "1.18.0",
-          "xunit.assert": "2.9.3",
-          "xunit.core": "[2.9.3]"
+          "Microsoft.Testing.Extensions.CodeCoverage": "18.5.2",
+          "Microsoft.Testing.Extensions.Telemetry": "2.1.0",
+          "Microsoft.Testing.Extensions.TrxReport": "2.1.0",
+          "TUnit.Assertions": "1.18.37",
+          "TUnit.Engine": "1.18.37"
         }
-      },
-      "xunit.runner.visualstudio": {
-        "type": "Direct",
-        "requested": "[2.8.2, )",
-        "resolved": "2.8.2",
-        "contentHash": "vm1tbfXhFmjFMUmS4M0J0ASXz3/U5XvXBa6DOQUL3fEz4Vt6YPhv+ESCarx6M6D+9kJkJYZKCNvJMas1+nVfmQ=="
       },
       "Castle.Core": {
         "type": "Transitive",
@@ -58,10 +38,20 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
-      "Microsoft.CodeCoverage": {
+      "EnumerableAsyncProcessor": {
         "type": "Transitive",
-        "resolved": "17.12.0",
-        "contentHash": "4svMznBd5JM21JIG2xZKGNanAHNXplxf/kQDFfLHXQ3OnpJkayRK/TjacFjA+EYmoyuNXHo/sOETEfcYtAzIrA=="
+        "resolved": "3.8.4",
+        "contentHash": "KlbpupRCz3Kf+P7gsiDvFXJ980i/9lfihMZFmmxIk0Gf6mopEjy74OTJZmdaKDQpE29eQDBnMZB5khyW3eugrg=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.DiaSymReader": {
+        "type": "Transitive",
+        "resolved": "2.2.3",
+        "contentHash": "bhwzJfzyiJM0nXJyNB7Y9OfsEXyxLdDBHG99soIp5JjnPydwkOaBdRCtRtWgQh3noSLi2cSIZ/wpbHNNE9knxQ=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Transitive",
@@ -92,6 +82,11 @@
           "Microsoft.Extensions.Primitives": "10.0.0"
         }
       },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "8.0.2",
+        "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
+      },
       "Microsoft.Extensions.FileProviders.Abstractions": {
         "type": "Transitive",
         "resolved": "10.0.0",
@@ -120,68 +115,80 @@
         "resolved": "10.0.0",
         "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
       },
-      "Microsoft.TestPlatform.ObjectModel": {
+      "Microsoft.Testing.Extensions.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.12.0",
-        "contentHash": "TDqkTKLfQuAaPcEb3pDDWnh7b3SyZF+/W9OZvWFp6eJCIiiYFdSB6taE2I6tWrFw5ywhzOb6sreoGJTI6m3rSQ=="
-      },
-      "Microsoft.TestPlatform.TestHost": {
-        "type": "Transitive",
-        "resolved": "17.12.0",
-        "contentHash": "MiPEJQNyADfwZ4pJNpQex+t9/jOClBGMiCiVVFuELCMSX2nmNfvUor3uFVxNNCg30uxDP8JDYfPnMXQzsfzYyg==",
+        "resolved": "18.5.2",
+        "contentHash": "UNcGLx9pVtlXF8MPDR8KDp+/OKKNIJjpzwRyZSt609TSGvaD8mtuQMb5GKZvhMucPp0a5Juvn3kxXDceQZWmAg==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.12.0",
-          "Newtonsoft.Json": "13.0.1"
+          "Microsoft.DiaSymReader": "2.2.3",
+          "Microsoft.Extensions.DependencyModel": "8.0.2",
+          "Microsoft.Testing.Platform": "2.1.0"
         }
       },
-      "Newtonsoft.Json": {
+      "Microsoft.Testing.Extensions.Telemetry": {
         "type": "Transitive",
-        "resolved": "13.0.1",
-        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+        "resolved": "2.1.0",
+        "contentHash": "5TwgTx2u7k9Al/xbZ18QXq4Hdy2xewkVTI6K3sk+jY2ykqUkIKNuj7rFu3GOV5KnEUkevhw6eZcyZs77STHJIA==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Testing.Platform": "2.1.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "cXmP225WcMLLOSrW8xekaNhfzdBwXX3cbXbE5qSzmLbK0KZe3z8rAObKj70FWiPPPzm2W22x0ZW93gsmAfK6Mg==",
+        "dependencies": {
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
+          "Microsoft.Testing.Platform": "2.1.0"
+        }
+      },
+      "Microsoft.Testing.Extensions.TrxReport.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "D8xmIJYQFJ6D49Rx5/vPrkZZxb338Jkew+eSqZLBfBiWKw4QZKy3i1BOXiLfz0lOmaNErwDz/YWRojCdNl+B9Q==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.1.0"
+        }
+      },
+      "Microsoft.Testing.Platform": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "aHkjNTGIA+Zbdw6RJgSFrbDrCjO0CgqpElqYcvkRSeUhBv2bKarnvU3ep786U7UqrPlArT/B7VmImRibJD0Zrg=="
+      },
+      "Microsoft.Testing.Platform.MSBuild": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "UpfPebXQtHGrWz21+YLHmJSm+5zsuPE9U9pfdCtoB+67g75fDmWlNgpkH2ZmdVhSwkjNIed9Icg8Iu63z2ei5Q==",
+        "dependencies": {
+          "Microsoft.Testing.Platform": "2.1.0"
+        }
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
-      "xunit.abstractions": {
+      "TUnit.Assertions": {
         "type": "Transitive",
-        "resolved": "2.0.3",
-        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+        "resolved": "1.18.37",
+        "contentHash": "LvSHEFtAYxsYeISQi6eagYypRxt0NKRkUzHIE4UkAbn/cw+Sws4iiw8mLal+6Q0ZbcoCSUV/pdGa7deBkLxjpg=="
       },
-      "xunit.analyzers": {
+      "TUnit.Core": {
         "type": "Transitive",
-        "resolved": "1.18.0",
-        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+        "resolved": "1.18.37",
+        "contentHash": "tHHuPhkVlkxoXcH2A8PagcZVB9KVN0WzOvi6qfTebWp1PDZu8tTnxubthWyxptSUJDIWfzi5uUivgDzBOSfSDQ=="
       },
-      "xunit.assert": {
+      "TUnit.Engine": {
         "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
-      },
-      "xunit.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "resolved": "1.18.37",
+        "contentHash": "vs3wee7E2gzo3XDb5glGfxTWmJvLs4xt0nm8+bdsaYxshFFA23/Mwo2HZHr1gYenxDrKCjcJxTrUTC883wAu6A==",
         "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]",
-          "xunit.extensibility.execution": "[2.9.3]"
-        }
-      },
-      "xunit.extensibility.core": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
-        "dependencies": {
-          "xunit.abstractions": "2.0.3"
-        }
-      },
-      "xunit.extensibility.execution": {
-        "type": "Transitive",
-        "resolved": "2.9.3",
-        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
-        "dependencies": {
-          "xunit.extensibility.core": "[2.9.3]"
+          "EnumerableAsyncProcessor": "3.8.4",
+          "Microsoft.Testing.Extensions.TrxReport.Abstractions": "2.1.0",
+          "Microsoft.Testing.Platform": "2.1.0",
+          "Microsoft.Testing.Platform.MSBuild": "2.1.0",
+          "TUnit.Core": "1.18.37"
         }
       },
       "devsweep": {


### PR DESCRIPTION
This pull request migrates the project's .NET test suite from xUnit to TUnit and updates the test runner configuration to use Microsoft.Testing.Platform. All test attributes and related usages have been converted to TUnit equivalents, and the test classes have been made `internal sealed` for improved encapsulation.

Test framework migration:

* Removed `xunit` and `xunit.runner.visualstudio` packages and added the `TUnit` package in `Directory.Packages.props`.
* Replaced `[Fact]` and `[Theory]`/`[InlineData]` attributes with `[Test]` and `[Arguments]` from TUnit in all test files, and updated test class declarations to `internal sealed class`. [[1]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL5-R10) [[2]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL21-R28) [[3]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL55-R54) [[4]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL84-R83) [[5]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL97-R96) [[6]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL110-R109) [[7]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL129-R128) [[8]](diffhunk://#diff-65dfd6b5403f20d4ba0e867d512a0da9def53c54bb5be863d6d58196acb5e44aL139-R138) [[9]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL3-R16) [[10]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL26-R25) [[11]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL35-R34) [[12]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL45-R44) [[13]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL55-R54) [[14]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL65-R64) [[15]](diffhunk://#diff-08e9cadcdd60fb94c134b34d08cf1078451c23cfb4abb3c011856d2fa52e69fbL75-R74) [[16]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L5-R10) [[17]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L25-R32) [[18]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L56-R55) [[19]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L82-R81) [[20]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L103-R102) [[21]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L124-R123) [[22]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L134-R133) [[23]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L150-R149) [[24]](diffhunk://#diff-70586af5dc3d6bde8600ca84b976883cf4f63f0492a6a7594f29c2dfb83a7a41L159-R158) [[25]](diffhunk://#diff-76a9f080e6376d552dc589daf56cb3f671c3de97c00303338385a2ee83c33f89L4-R19) [[26]](diffhunk://#diff-76a9f080e6376d552dc589daf56cb3f671c3de97c00303338385a2ee83c33f89L29-R28) [[27]](diffhunk://#diff-76a9f080e6376d552dc589daf56cb3f671c3de97c00303338385a2ee83c33f89L39-R38) [[28]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L3-R10) [[29]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L28-R25) [[30]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L39-R36) [[31]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L58-R55) [[32]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L68-R65) [[33]](diffhunk://#diff-aba6958523af6e811b46a5a944abca20515c08b5a8ebaa839269a251087aaf74L88-R85)

Test runner configuration:

* Added `global.json` to specify the use of `Microsoft.Testing.Platform` as the test runner.

related to [Issue#49](https://github.com/Sstark97/dev_sweep/issues/49)