### PR TITLE
feat(tests): unified test classes names

### DIFF
--- a/net/tests/DevSweep.Tests/Domain/Common/ResultBindShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultBindShould.cs
@@ -4,7 +4,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultBindTests
+internal sealed class ResultBindShould
 {
     [Test]
     public void ChainsSuccessfulOperations()

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultFailureShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultFailureShould.cs
@@ -3,7 +3,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultFailureTests
+internal sealed class ResultFailureShould
 {
     [Test]
     public void IsFailureReturnsTrueForFailureResult()

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultLinqQuerySyntaxShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultLinqQuerySyntaxShould.cs
@@ -3,7 +3,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultLinqQuerySyntaxTests
+internal sealed class ResultLinqQuerySyntaxShould
 {
     [Test]
     public void TransformsValueUsingSelectSyntax()

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultMapShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultMapShould.cs
@@ -4,7 +4,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultMapTests
+internal sealed class ResultMapShould
 {
     [Test]
     public void TransformsValueWhenResultIsSuccess()

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultMatchShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultMatchShould.cs
@@ -3,7 +3,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultMatchTests
+internal sealed class ResultMatchShould
 {
     [Test]
     public void ExecutesSuccessFunctionWhenResultIsSuccess()

--- a/net/tests/DevSweep.Tests/Domain/Common/ResultSuccessShould.cs
+++ b/net/tests/DevSweep.Tests/Domain/Common/ResultSuccessShould.cs
@@ -3,7 +3,7 @@ using DevSweep.Domain.Common;
 
 namespace DevSweep.Tests.Domain.Common;
 
-internal sealed class ResultSuccessTests
+internal sealed class ResultSuccessShould
 {
     [Test]
     public void IsSuccessReturnsTrueForSuccessResult()


### PR DESCRIPTION
This pull request refactors several test class names and their corresponding file names in the `DevSweep.Tests.Domain.Common` namespace to follow a consistent naming convention. Specifically, it changes class and file names from the `*Tests` format to the `*Should` format, improving clarity and aligning with common unit testing practices.

**Test class and file renaming for consistency:**

* Renamed `ResultBindTests` to `ResultBindShould` and updated the file name accordingly.
* Renamed `ResultFailureTests` to `ResultFailureShould` and updated the file name accordingly.
* Renamed `ResultLinqQuerySyntaxTests` to `ResultLinqQuerySyntaxShould` and updated the file name accordingly.
* Renamed `ResultMapTests` to `ResultMapShould` and updated the file name accordingly.
* Renamed `ResultMatchTests` to `ResultMatchShould` and updated the file name accordingly.
* Renamed `ResultSuccessTests` to `ResultSuccessShould` and updated the file name accordingly.

It is related to [Issue#64](https://github.com/Sstark97/dev_sweep/issues/64)