### PR TITLE
feat(infrastructure): wire DI composition root

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="AwesomeAssertions" Version="9.3.0" />

--- a/net/src/DevSweep/DevSweep.csproj
+++ b/net/src/DevSweep/DevSweep.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="DotMake.CommandLine" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Spectre.Console" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/net/src/DevSweep/Infrastructure/Cli/Composition/ServiceRegistration.cs
+++ b/net/src/DevSweep/Infrastructure/Cli/Composition/ServiceRegistration.cs
@@ -1,0 +1,116 @@
+using DevSweep.Application.Modules;
+using DevSweep.Application.Ports.Driven;
+using DevSweep.Application.Ports.Driving;
+using DevSweep.Application.UseCases;
+using DevSweep.Domain.Enums;
+using DevSweep.Infrastructure.Cli.Interaction;
+using DevSweep.Infrastructure.Cli.Output;
+using DevSweep.Infrastructure.Environment;
+using DevSweep.Infrastructure.FileSystem;
+using DevSweep.Infrastructure.Modules.DevTools;
+using DevSweep.Infrastructure.Modules.Docker;
+using DevSweep.Infrastructure.Modules.Homebrew;
+using DevSweep.Infrastructure.Modules.JetBrains;
+using DevSweep.Infrastructure.Modules.Projects;
+using DevSweep.Infrastructure.Modules.System;
+using DevSweep.Infrastructure.Process;
+using Microsoft.Extensions.DependencyInjection;
+using Spectre.Console;
+
+namespace DevSweep.Infrastructure.Cli.Composition;
+
+internal static class ServiceRegistration
+{
+    internal static IServiceCollection AddDevSweepServices(
+        this IServiceCollection services,
+        OutputStrategy outputStrategy,
+        bool autoConfirm)
+    {
+        services.AddSingleton<IFileSystem, PhysicalFileSystem>();
+        services.AddSingleton<IProcessManager, SystemProcessManager>();
+        services.AddSingleton<ICommandRunner, SystemCommandRunner>();
+        services.AddSingleton<IEnvironmentProvider, SystemEnvironmentProvider>();
+
+        services.AddSingleton<IOutputFormatter>(outputStrategy switch
+        {
+            OutputStrategy.Plain => _ => new PlainTextOutputFormatter(Console.Out),
+            OutputStrategy.Json => _ => new JsonOutputFormatter(Console.Out),
+            _ => _ => new SpectreOutputFormatter(AnsiConsole.Console)
+        });
+
+        if (autoConfirm)
+            services.AddSingleton<IUserInteraction, AutoConfirmInteraction>();
+        else
+            services.AddSingleton<IUserInteraction>(_ => new InteractiveConsole(AnsiConsole.Console));
+
+        if (autoConfirm)
+            services.AddSingleton<IModuleSelector, SelectAllModules>();
+        else
+            services.AddSingleton<IModuleSelector>(_ => new InteractiveMenu(AnsiConsole.Console));
+
+        services.AddSingleton<DockerCliRuntimeStrategy>();
+        services.AddSingleton<OrbStackRuntimeStrategy>();
+        services.AddSingleton<IReadOnlyList<IContainerRuntimeStrategy>>(sp =>
+        [
+            sp.GetRequiredService<DockerCliRuntimeStrategy>(),
+            sp.GetRequiredService<OrbStackRuntimeStrategy>()
+        ]);
+
+        services.AddSingleton<MavenCleaner>();
+        services.AddSingleton<GradleCleaner>();
+        services.AddSingleton<NodeCleaner>();
+        services.AddSingleton<PythonCleaner>();
+        services.AddSingleton<SdkmanCleaner>();
+        services.AddSingleton<IReadOnlyList<IDevToolsCleaner>>(sp =>
+        [
+            sp.GetRequiredService<MavenCleaner>(),
+            sp.GetRequiredService<GradleCleaner>(),
+            sp.GetRequiredService<NodeCleaner>(),
+            sp.GetRequiredService<PythonCleaner>(),
+            sp.GetRequiredService<SdkmanCleaner>()
+        ]);
+
+        services.AddSingleton<IReadOnlyList<IStaleProjectCleaner>>(_ =>
+        [
+            new StaleNodeProjectCleaner(),
+            new StaleMavenProjectCleaner(),
+            new StaleGradleProjectCleaner(),
+            new StalePythonProjectCleaner()
+        ]);
+
+        services.AddSingleton<SystemCacheCleaner>();
+        services.AddSingleton<SystemLogsCleaner>();
+        services.AddSingleton<SystemTempCleaner>();
+        services.AddSingleton<IReadOnlyList<ISystemCleaner>>(sp =>
+        [
+            sp.GetRequiredService<SystemCacheCleaner>(),
+            sp.GetRequiredService<SystemLogsCleaner>(),
+            sp.GetRequiredService<SystemTempCleaner>()
+        ]);
+
+        services.AddSingleton<JetBrainsModule>();
+        services.AddSingleton<DockerModule>();
+        services.AddSingleton<HomebrewModule>();
+        services.AddSingleton<DevToolsModule>();
+        services.AddSingleton<StaleProjectsModule>();
+        services.AddSingleton<SystemModule>();
+
+        services.AddSingleton(sp =>
+        {
+            var registry = new ModuleRegistry();
+            registry.Register(sp.GetRequiredService<JetBrainsModule>());
+            registry.Register(sp.GetRequiredService<DockerModule>());
+            registry.Register(sp.GetRequiredService<HomebrewModule>());
+            registry.Register(sp.GetRequiredService<DevToolsModule>());
+            registry.Register(sp.GetRequiredService<StaleProjectsModule>());
+            registry.Register(sp.GetRequiredService<SystemModule>());
+            return registry;
+        });
+
+        services.AddSingleton<IAnalyzeUseCase, AnalyzeUseCase>();
+        services.AddSingleton<ICleanupUseCase, CleanupUseCase>();
+        services.AddSingleton<IAvailableModulesUseCase, AvailableModulesUseCase>();
+
+        return services;
+    }
+}

--- a/net/src/DevSweep/Program.cs
+++ b/net/src/DevSweep/Program.cs
@@ -1,4 +1,6 @@
+using DevSweep.Domain.Enums;
 using DevSweep.Infrastructure.Cli.Commands;
+using DevSweep.Infrastructure.Cli.Composition;
 using DotMake.CommandLine;
 
 namespace DevSweep;
@@ -7,6 +9,38 @@ internal sealed class Program
 {
     private static async Task<int> Main(string[] args)
     {
+        var (outputStrategy, autoConfirm) = ParseGlobalOptions(args);
+
+        Cli.Ext.ConfigureServices(services =>
+        {
+            services.AddDevSweepServices(outputStrategy, autoConfirm);
+        });
+
         return await Cli.RunAsync<RootCommand>(args);
+    }
+
+    private static (OutputStrategy outputStrategy, bool autoConfirm) ParseGlobalOptions(string[] args)
+    {
+        var outputStrategy = OutputStrategy.Rich;
+        var autoConfirm = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--output" && i + 1 < args.Length)
+            {
+                outputStrategy = args[i + 1].ToUpperInvariant() switch
+                {
+                    "PLAIN" => OutputStrategy.Plain,
+                    "JSON" => OutputStrategy.Json,
+                    _ => OutputStrategy.Rich
+                };
+            }
+            else if (args[i] is "--force" or "-f" or "-y")
+            {
+                autoConfirm = true;
+            }
+        }
+
+        return (outputStrategy, autoConfirm);
     }
 }

--- a/net/src/DevSweep/packages.lock.json
+++ b/net/src/DevSweep/packages.lock.json
@@ -26,6 +26,15 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "10.0.0"
         }
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Direct",
         "requested": "[10.0.5, )",

--- a/net/tests/DevSweep.Tests/DevSweep.Tests.csproj
+++ b/net/tests/DevSweep.Tests/DevSweep.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Spectre.Console.Testing" />
     <PackageReference Include="TUnit" />
     <PackageReference Include="NSubstitute" />

--- a/net/tests/DevSweep.Tests/Infrastructure/Cli/Composition/ServiceRegistrationShould.cs
+++ b/net/tests/DevSweep.Tests/Infrastructure/Cli/Composition/ServiceRegistrationShould.cs
@@ -1,0 +1,200 @@
+using AwesomeAssertions;
+using DevSweep.Application.Modules;
+using DevSweep.Application.Ports.Driven;
+using DevSweep.Application.Ports.Driving;
+using DevSweep.Application.UseCases;
+using DevSweep.Domain.Enums;
+using DevSweep.Infrastructure.Cli.Composition;
+using DevSweep.Infrastructure.Cli.Interaction;
+using DevSweep.Infrastructure.Cli.Output;
+using DevSweep.Infrastructure.Environment;
+using DevSweep.Infrastructure.FileSystem;
+using DevSweep.Infrastructure.Process;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DevSweep.Tests.Infrastructure.Cli.Composition;
+
+internal sealed class ServiceRegistrationShould
+{
+    private static readonly int RegisteredModuleCount = new[]
+    {
+        CleanupModuleName.JetBrains,
+        CleanupModuleName.Docker,
+        CleanupModuleName.Homebrew,
+        CleanupModuleName.DevTools,
+        CleanupModuleName.Projects,
+        CleanupModuleName.System
+    }.Length;
+
+    private static ServiceProvider BuildProvider() =>
+        BuildProvider(OutputStrategy.Rich, false);
+
+    private static ServiceProvider BuildProvider(OutputStrategy output) =>
+        BuildProvider(output, false);
+
+    private static ServiceProvider BuildProvider(bool autoConfirm) =>
+        BuildProvider(OutputStrategy.Rich, autoConfirm);
+
+    private static ServiceProvider BuildProvider(OutputStrategy output, bool autoConfirm) =>
+        new ServiceCollection()
+            .AddDevSweepServices(output, autoConfirm)
+            .BuildServiceProvider();
+
+    [Test]
+    public void ProvidePhysicalFileSystem()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<IFileSystem>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<PhysicalFileSystem>();
+    }
+
+    [Test]
+    public void ProvideSystemProcessManager()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<IProcessManager>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<SystemProcessManager>();
+    }
+
+    [Test]
+    public void ProvideSystemCommandRunner()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<ICommandRunner>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<SystemCommandRunner>();
+    }
+
+    [Test]
+    public void ProvideSystemEnvironmentProvider()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<IEnvironmentProvider>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<SystemEnvironmentProvider>();
+    }
+
+    [Test]
+    public void ProvideSpectreOutputFormatterWhenRichStrategy()
+    {
+        using var provider = BuildProvider(OutputStrategy.Rich);
+
+        var resolved = provider.GetService<IOutputFormatter>();
+
+        resolved.Should().BeOfType<SpectreOutputFormatter>();
+    }
+
+    [Test]
+    public void ProvidePlainTextOutputFormatterWhenPlainStrategy()
+    {
+        using var provider = BuildProvider(OutputStrategy.Plain);
+
+        var resolved = provider.GetService<IOutputFormatter>();
+
+        resolved.Should().BeOfType<PlainTextOutputFormatter>();
+    }
+
+    [Test]
+    public void ProvideJsonOutputFormatterWhenJsonStrategy()
+    {
+        using var provider = BuildProvider(OutputStrategy.Json);
+
+        var resolved = provider.GetService<IOutputFormatter>();
+
+        resolved.Should().BeOfType<JsonOutputFormatter>();
+    }
+
+    [Test]
+    public void ProvideAutoConfirmInteractionWhenAutoConfirmEnabled()
+    {
+        using var provider = BuildProvider(true);
+
+        var resolved = provider.GetService<IUserInteraction>();
+
+        resolved.Should().BeOfType<AutoConfirmInteraction>();
+    }
+
+    [Test]
+    public void ProvideInteractiveConsoleWhenAutoConfirmDisabled()
+    {
+        using var provider = BuildProvider(false);
+
+        var resolved = provider.GetService<IUserInteraction>();
+
+        resolved.Should().BeOfType<InteractiveConsole>();
+    }
+
+    [Test]
+    public void ProvideSelectAllModulesWhenAutoConfirmEnabled()
+    {
+        using var provider = BuildProvider(true);
+
+        var resolved = provider.GetService<IModuleSelector>();
+
+        resolved.Should().BeOfType<SelectAllModules>();
+    }
+
+    [Test]
+    public void ProvideInteractiveMenuWhenAutoConfirmDisabled()
+    {
+        using var provider = BuildProvider(false);
+
+        var resolved = provider.GetService<IModuleSelector>();
+
+        resolved.Should().BeOfType<InteractiveMenu>();
+    }
+
+    [Test]
+    public void ProvideAnalyzeUseCase()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<IAnalyzeUseCase>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<AnalyzeUseCase>();
+    }
+
+    [Test]
+    public void ProvideCleanupUseCase()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<ICleanupUseCase>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<CleanupUseCase>();
+    }
+
+    [Test]
+    public void ProvideAvailableModulesUseCase()
+    {
+        using var provider = BuildProvider();
+
+        var resolved = provider.GetService<IAvailableModulesUseCase>();
+
+        resolved.Should().NotBeNull();
+        resolved.Should().BeOfType<AvailableModulesUseCase>();
+    }
+
+    [Test]
+    public void RegisterAllCleanupModules()
+    {
+        using var provider = BuildProvider();
+
+        var registry = provider.GetRequiredService<ModuleRegistry>();
+        var modules = registry.Modules();
+
+        modules.Count.Should().Be(RegisteredModuleCount);
+    }
+}

--- a/net/tests/DevSweep.Tests/packages.lock.json
+++ b/net/tests/DevSweep.Tests/packages.lock.json
@@ -8,6 +8,15 @@
         "resolved": "9.3.0",
         "contentHash": "8lGLYap2ec2gNLgjf2xKZaKLpQ7j36oJvrYzBVVpNAumqnxRdevqqhEF66qxE92f8y2+zsbQ061DeHG61ZhzaQ=="
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
       "NSubstitute": {
         "type": "Direct",
         "requested": "[5.3.0, )",
@@ -205,6 +214,7 @@
         "dependencies": {
           "DotMake.CommandLine": "[2.0.0, )",
           "Microsoft.Extensions.Configuration.Json": "[10.0.0, )",
+          "Microsoft.Extensions.DependencyInjection": "[10.0.5, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
           "Spectre.Console": "[0.54.0, )"
         }


### PR DESCRIPTION
Closes #41

## Summary

Implements the DI composition root for the CLI infrastructure layer (Phase 5).

## Changes

### `Infrastructure/Cli/Composition/ServiceRegistration.cs`
- `AddDevSweepServices` extension method on `IServiceCollection`
- Registers domain services, use cases, infrastructure adapters, module registry, output formatter strategy, and interaction strategy
- Fully AOT-compatible (no reflection-based registration)

### `Program.cs`
- Wires `Cli.Ext.ConfigureServices` with `AddDevSweepServices`
- Pre-parses `--output` and `--force`/`-f`/`-y` flags to resolve strategies before DI setup

### Build
- Added `Microsoft.Extensions.DependencyInjection 10.0.5` package (direct dependency needed to call `BuildServiceProvider`)

## Tests

- `Infrastructure/Cli/Composition/ServiceRegistrationShould.cs`
  - All use cases resolve correctly
  - Output formatter strategy resolves per `OutputStrategy` value
  - Interaction strategy resolves per `autoConfirm` flag
  - Module registry contains all expected modules

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test` — 544/544 passed