### PR TITLE
feat(infrastructure): add CLI e2e smoke tests and dry-run support

### DIFF
--- a/net/src/DevSweep/Infrastructure/Cli/Commands/CleanCommand.cs
+++ b/net/src/DevSweep/Infrastructure/Cli/Commands/CleanCommand.cs
@@ -10,9 +10,13 @@ namespace DevSweep.Infrastructure.Cli.Commands;
 [CliCommand(Name = "clean", Description = "Clean developer caches", Parent = typeof(RootCommand))]
 public sealed class CleanCommand(
     ICleanupUseCase cleanupUseCase,
+    IAnalyzeUseCase analyzeUseCase,
     IAvailableModulesUseCase availableModulesUseCase,
     IOutputFormatter outputFormatter)
 {
+    [CliOption(Description = "Preview without deleting", Name = "--dry-run", Aliases = ["-d"])]
+    public bool DryRun { get; set; }
+
     [CliArgument(Description = "Module names to clean (e.g., jetbrains docker)")]
     public List<string> Modules { get; set; } = [];
 
@@ -39,6 +43,27 @@ public sealed class CleanCommand(
             return 1;
         }
 
+        if (DryRun)
+            return await ExecuteAnalysisAsync(moduleNames);
+
+        return await ExecuteCleanupAsync(moduleNames);
+    }
+
+    private async Task<int> ExecuteAnalysisAsync(IReadOnlyList<CleanupModuleName> moduleNames)
+    {
+        var result = await analyzeUseCase.Invoke(moduleNames, CancellationToken.None);
+
+        if (result.IsFailure)
+        {
+            outputFormatter.Error(result.Error.ToString());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private async Task<int> ExecuteCleanupAsync(IReadOnlyList<CleanupModuleName> moduleNames)
+    {
         var result = await cleanupUseCase.Invoke(moduleNames, CancellationToken.None);
 
         if (result.IsFailure)

--- a/net/src/DevSweep/Infrastructure/Cli/Commands/RootCommand.cs
+++ b/net/src/DevSweep/Infrastructure/Cli/Commands/RootCommand.cs
@@ -1,10 +1,18 @@
+using DevSweep.Application.Models;
 using DevSweep.Application.Ports.Driven;
+using DevSweep.Application.Ports.Driving;
+using DevSweep.Domain.Enums;
 using DotMake.CommandLine;
 
 namespace DevSweep.Infrastructure.Cli.Commands;
 
 [CliCommand(Description = "DevSweep - Developer cache cleaner")]
-public sealed class RootCommand(IOutputFormatter outputFormatter)
+public sealed class RootCommand(
+    IOutputFormatter outputFormatter,
+    IAvailableModulesUseCase availableModulesUseCase,
+    IModuleSelector moduleSelector,
+    IAnalyzeUseCase analyzeUseCase,
+    ICleanupUseCase cleanupUseCase)
 {
     [CliOption(Description = "Preview without deleting", Name = "--dry-run", Aliases = ["-d"])]
     public bool DryRun { get; set; }
@@ -18,9 +26,61 @@ public sealed class RootCommand(IOutputFormatter outputFormatter)
     [CliOption(Description = "Output format: rich, plain, json", Name = "--output")]
     public string Output { get; set; } = "rich";
 
-    public Task<int> RunAsync()
+    public async Task<int> RunAsync()
     {
-        outputFormatter.Info("Run 'devsweep --help' for usage information");
-        return Task.FromResult(0);
+        var version = typeof(RootCommand).Assembly.GetName().Version?.ToString() ?? "unknown";
+        outputFormatter.DisplayBanner(version);
+
+        var available = availableModulesUseCase.Invoke();
+
+        if (available.Count == 0)
+        {
+            outputFormatter.Info("No modules available on this platform.");
+            return 0;
+        }
+
+        var selectedModules = await SelectModulesAsync(available);
+
+        if (selectedModules.Count == 0)
+            return 0;
+
+        var analysisExitCode = await AnalyzeSelectedModulesAsync(selectedModules);
+        if (analysisExitCode != 0)
+            return analysisExitCode;
+
+        if (DryRun)
+            return 0;
+
+        return await CleanSelectedModulesAsync(selectedModules);
+    }
+
+    private async Task<IReadOnlyList<CleanupModuleName>> SelectModulesAsync(
+        IReadOnlyList<ModuleDescriptor> available) =>
+        await moduleSelector.SelectModulesAsync(available, CancellationToken.None);
+
+    private async Task<int> AnalyzeSelectedModulesAsync(IReadOnlyList<CleanupModuleName> modules)
+    {
+        var result = await analyzeUseCase.Invoke(modules, CancellationToken.None);
+
+        if (result.IsFailure)
+        {
+            outputFormatter.Error(result.Error.ToString());
+            return 1;
+        }
+
+        return 0;
+    }
+
+    private async Task<int> CleanSelectedModulesAsync(IReadOnlyList<CleanupModuleName> modules)
+    {
+        var result = await cleanupUseCase.Invoke(modules, CancellationToken.None);
+
+        if (result.IsFailure)
+        {
+            outputFormatter.Error(result.Error.ToString());
+            return 1;
+        }
+
+        return 0;
     }
 }

--- a/net/tests/DevSweep.Tests/Infrastructure/Cli/Commands/CleanCommandShould.cs
+++ b/net/tests/DevSweep.Tests/Infrastructure/Cli/Commands/CleanCommandShould.cs
@@ -14,6 +14,7 @@ namespace DevSweep.Tests.Infrastructure.Cli.Commands;
 internal sealed class CleanCommandShould
 {
     private readonly ICleanupUseCase cleanupUseCase = Substitute.For<ICleanupUseCase>();
+    private readonly IAnalyzeUseCase analyzeUseCase = Substitute.For<IAnalyzeUseCase>();
     private readonly IAvailableModulesUseCase availableModulesUseCase = Substitute.For<IAvailableModulesUseCase>();
     private readonly IOutputFormatter outputFormatter = Substitute.For<IOutputFormatter>();
 
@@ -21,7 +22,7 @@ internal sealed class CleanCommandShould
     public async Task CleanSpecifiedModulesSuccessfully()
     {
         GivenCleanupSucceeds();
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             Modules = ["docker"]
         };
@@ -39,7 +40,7 @@ internal sealed class CleanCommandShould
     {
         GivenAvailableModulesReturns([CleanupModuleName.Docker, CleanupModuleName.Homebrew]);
         GivenCleanupSucceeds();
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             All = true
         };
@@ -56,7 +57,7 @@ internal sealed class CleanCommandShould
     [Test]
     public async Task FailWhenNuclearWithoutDevToolsModule()
     {
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             Modules = ["docker"],
             Nuclear = true
@@ -72,7 +73,7 @@ internal sealed class CleanCommandShould
     public async Task AllowNuclearWithDevToolsModule()
     {
         GivenCleanupSucceeds();
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             Modules = ["devtools"],
             Nuclear = true
@@ -89,7 +90,7 @@ internal sealed class CleanCommandShould
     [Test]
     public async Task FailWhenNoModulesSpecifiedAndAllNotSet()
     {
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             Modules = [],
             All = false
@@ -105,7 +106,7 @@ internal sealed class CleanCommandShould
     public async Task FailWhenCleanupReturnsError()
     {
         GivenCleanupFails(DomainError.InvalidOperation("Cleanup failed"));
-        var command = new CleanCommand(cleanupUseCase, availableModulesUseCase, outputFormatter)
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
         {
             Modules = ["docker"]
         };
@@ -114,6 +115,62 @@ internal sealed class CleanCommandShould
 
         exitCode.Should().Be(1);
         outputFormatter.Received().Error(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task RunAnalysisInsteadOfCleanupWhenDryRunIsEnabled()
+    {
+        GivenAnalysisSucceeds();
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
+        {
+            Modules = ["docker"],
+            DryRun = true
+        };
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(0);
+        await analyzeUseCase.Received().Invoke(
+            Arg.Is<IReadOnlyList<CleanupModuleName>>(m => m.Contains(CleanupModuleName.Docker)),
+            Arg.Any<CancellationToken>());
+        await cleanupUseCase.DidNotReceive().Invoke(
+            Arg.Any<IReadOnlyList<CleanupModuleName>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FailWhenAnalysisFailsInDryRunMode()
+    {
+        GivenAnalysisFails(DomainError.InvalidOperation("Boom"));
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
+        {
+            Modules = ["docker"],
+            DryRun = true
+        };
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(1);
+        outputFormatter.Received().Error(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task NotInvokeAnalysisWhenDryRunIsNotSet()
+    {
+        GivenCleanupSucceeds();
+        var command = new CleanCommand(cleanupUseCase, analyzeUseCase, availableModulesUseCase, outputFormatter)
+        {
+            Modules = ["docker"]
+        };
+
+        await command.RunAsync();
+
+        await analyzeUseCase.DidNotReceive().Invoke(
+            Arg.Any<IReadOnlyList<CleanupModuleName>>(),
+            Arg.Any<CancellationToken>());
+        await cleanupUseCase.Received().Invoke(
+            Arg.Is<IReadOnlyList<CleanupModuleName>>(m => m.Contains(CleanupModuleName.Docker)),
+            Arg.Any<CancellationToken>());
     }
 
     private void GivenCleanupSucceeds()
@@ -128,6 +185,19 @@ internal sealed class CleanCommandShould
         cleanupUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(
                 Result<IReadOnlyList<CleanupSummary>, DomainError>.Failure(error)));
+    }
+
+    private void GivenAnalysisSucceeds()
+    {
+        var emptyReport = AnalysisReport.Create([]).Value;
+        analyzeUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<AnalysisReport, DomainError>.Success(emptyReport)));
+    }
+
+    private void GivenAnalysisFails(DomainError error)
+    {
+        analyzeUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<AnalysisReport, DomainError>.Failure(error)));
     }
 
     private void GivenAvailableModulesReturns(IReadOnlyList<CleanupModuleName> modules)

--- a/net/tests/DevSweep.Tests/Infrastructure/Cli/Commands/RootCommandShould.cs
+++ b/net/tests/DevSweep.Tests/Infrastructure/Cli/Commands/RootCommandShould.cs
@@ -1,5 +1,11 @@
 using AwesomeAssertions;
+using DevSweep.Application.Models;
 using DevSweep.Application.Ports.Driven;
+using DevSweep.Application.Ports.Driving;
+using DevSweep.Domain.Common;
+using DevSweep.Domain.Entities;
+using DevSweep.Domain.Enums;
+using DevSweep.Domain.Errors;
 using DevSweep.Infrastructure.Cli.Commands;
 using NSubstitute;
 
@@ -8,24 +14,222 @@ namespace DevSweep.Tests.Infrastructure.Cli.Commands;
 internal sealed class RootCommandShould
 {
     private readonly IOutputFormatter outputFormatter = Substitute.For<IOutputFormatter>();
+    private readonly IAvailableModulesUseCase availableModulesUseCase = Substitute.For<IAvailableModulesUseCase>();
+    private readonly IModuleSelector moduleSelector = Substitute.For<IModuleSelector>();
+    private readonly IAnalyzeUseCase analyzeUseCase = Substitute.For<IAnalyzeUseCase>();
+    private readonly ICleanupUseCase cleanupUseCase = Substitute.For<ICleanupUseCase>();
 
     [Test]
-    public async Task DisplayHelpMessageWhenInvokedDirectly()
+    public async Task DisplayBannerWhenInvokedWithoutSubcommand()
     {
-        var command = new RootCommand(outputFormatter);
+        GivenNoAvailableModules();
+        var command = BuildCommand();
 
         await command.RunAsync();
 
-        outputFormatter.Received().Info(Arg.Any<string>());
+        outputFormatter.Received().DisplayBanner(Arg.Any<string>());
     }
 
     [Test]
-    public async Task ReturnSuccessExitCode()
+    public async Task ExitGracefullyWhenNoModulesAvailable()
     {
-        var command = new RootCommand(outputFormatter);
+        GivenNoAvailableModules();
+        var command = BuildCommand();
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(0);
+        await moduleSelector.DidNotReceive().SelectModulesAsync(
+            Arg.Any<IReadOnlyList<ModuleDescriptor>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task PresentModuleSelectionWhenModulesAvailable()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsNoModules();
+        var command = BuildCommand();
+
+        await command.RunAsync();
+
+        await moduleSelector.Received().SelectModulesAsync(
+            Arg.Is<IReadOnlyList<ModuleDescriptor>>(m => m.Count == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ExitGracefullyWhenUserSelectsNoModules()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsNoModules();
+        var command = BuildCommand();
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(0);
+        await analyzeUseCase.DidNotReceive().Invoke(
+            Arg.Any<IReadOnlyList<CleanupModuleName>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunAnalysisForSelectedModules()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        GivenCleanupSucceeds();
+        var command = BuildCommand();
+
+        await command.RunAsync();
+
+        await analyzeUseCase.Received().Invoke(
+            Arg.Is<IReadOnlyList<CleanupModuleName>>(m => m.Contains(CleanupModuleName.Docker)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunCleanupAfterAnalysis()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        GivenCleanupSucceeds();
+        var command = BuildCommand();
+
+        await command.RunAsync();
+
+        await cleanupUseCase.Received().Invoke(
+            Arg.Is<IReadOnlyList<CleanupModuleName>>(m => m.Contains(CleanupModuleName.Docker)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task SkipCleanupWhenDryRunIsEnabled()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        var command = BuildCommand();
+        command.DryRun = true;
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(0);
+        await cleanupUseCase.DidNotReceive().Invoke(
+            Arg.Any<IReadOnlyList<CleanupModuleName>>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task RunAnalysisWhenDryRunIsEnabled()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        var command = BuildCommand();
+        command.DryRun = true;
+
+        await command.RunAsync();
+
+        await analyzeUseCase.Received().Invoke(
+            Arg.Is<IReadOnlyList<CleanupModuleName>>(m => m.Contains(CleanupModuleName.Docker)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FailWhenAnalysisEncountersError()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisFails("Analysis error");
+        var command = BuildCommand();
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(1);
+        outputFormatter.Received().Error(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task FailWhenCleanupEncountersError()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        GivenCleanupFails("Cleanup error");
+        var command = BuildCommand();
+
+        var exitCode = await command.RunAsync();
+
+        exitCode.Should().Be(1);
+        outputFormatter.Received().Error(Arg.Any<string>());
+    }
+
+    [Test]
+    public async Task SucceedWhenFullFlowCompletes()
+    {
+        var dockerDescriptor = ModuleDescriptor.Create(CleanupModuleName.Docker, "Docker cache", false).Value;
+        GivenAvailableModules([dockerDescriptor]);
+        GivenUserSelectsModules([CleanupModuleName.Docker]);
+        GivenAnalysisSucceeds();
+        GivenCleanupSucceeds();
+        var command = BuildCommand();
 
         var exitCode = await command.RunAsync();
 
         exitCode.Should().Be(0);
     }
+
+    private RootCommand BuildCommand() =>
+        new(outputFormatter, availableModulesUseCase, moduleSelector, analyzeUseCase, cleanupUseCase);
+
+    private void GivenNoAvailableModules() =>
+        availableModulesUseCase.Invoke().Returns([]);
+
+    private void GivenAvailableModules(IReadOnlyList<ModuleDescriptor> modules) =>
+        availableModulesUseCase.Invoke().Returns(modules);
+
+    private void GivenUserSelectsModules(IReadOnlyList<CleanupModuleName> modules) =>
+        moduleSelector.SelectModulesAsync(
+            Arg.Any<IReadOnlyList<ModuleDescriptor>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(modules));
+
+    private void GivenUserSelectsNoModules() =>
+        moduleSelector.SelectModulesAsync(
+            Arg.Any<IReadOnlyList<ModuleDescriptor>>(),
+            Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<IReadOnlyList<CleanupModuleName>>([]));
+
+    private void GivenAnalysisSucceeds()
+    {
+        var emptyReport = AnalysisReport.Create([]).Value;
+        analyzeUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(Result<AnalysisReport, DomainError>.Success(emptyReport)));
+    }
+
+    private void GivenAnalysisFails(string errorMessage) =>
+        analyzeUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<AnalysisReport, DomainError>.Failure(DomainError.InvalidOperation(errorMessage))));
+
+    private void GivenCleanupSucceeds() =>
+        cleanupUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<IReadOnlyList<CleanupSummary>, DomainError>.Success([])));
+
+    private void GivenCleanupFails(string errorMessage) =>
+        cleanupUseCase.Invoke(Arg.Any<IReadOnlyList<CleanupModuleName>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(
+                Result<IReadOnlyList<CleanupSummary>, DomainError>.Failure(DomainError.InvalidOperation(errorMessage))));
 }

--- a/net/tests/DevSweep.Tests/Infrastructure/Cli/E2E/CliProcessRunner.cs
+++ b/net/tests/DevSweep.Tests/Infrastructure/Cli/E2E/CliProcessRunner.cs
@@ -1,0 +1,58 @@
+namespace DevSweep.Tests.Infrastructure.Cli.E2E;
+
+internal sealed record CliProcessResult(int ExitCode, string StandardOutput, string StandardError);
+
+internal static class CliProcessRunner
+{
+    private static readonly string ProjectPath = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "src", "DevSweep", "DevSweep.csproj"));
+
+    public static async Task<CliProcessResult> RunAsync(string arguments, CancellationToken cancellationToken)
+    {
+        var binaryPath = System.Environment.GetEnvironmentVariable("DEVSWEEP_BINARY_PATH");
+
+        var startInfo = binaryPath is not null
+            ? new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = binaryPath,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+            : new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"run --project {ProjectPath} --no-build -- {arguments}",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+        using var process = new System.Diagnostics.Process { StartInfo = startInfo };
+        process.Start();
+
+        var stdoutTask = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderrTask = process.StandardError.ReadToEndAsync(cancellationToken);
+
+        try
+        {
+            await Task.WhenAll(
+                stdoutTask,
+                stderrTask,
+                process.WaitForExitAsync(cancellationToken));
+        }
+        catch (OperationCanceledException)
+        {
+            process.Kill(entireProcessTree: true);
+            throw;
+        }
+
+        var stdout = await stdoutTask;
+        var stderr = await stderrTask;
+
+        return new CliProcessResult(process.ExitCode, stdout, stderr);
+    }
+}

--- a/net/tests/DevSweep.Tests/Infrastructure/Cli/E2E/SmokeTestsShould.cs
+++ b/net/tests/DevSweep.Tests/Infrastructure/Cli/E2E/SmokeTestsShould.cs
@@ -1,0 +1,161 @@
+using AwesomeAssertions;
+
+namespace DevSweep.Tests.Infrastructure.Cli.E2E;
+
+internal sealed class SmokeTestsShould
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan LongTestTimeout = TimeSpan.FromSeconds(180);
+
+    [Test]
+    public async Task DisplayHelpTextWhenHelpFlagProvided()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("--help", cts.Token);
+
+        var exitCode = result.ExitCode;
+        var output = result.StandardOutput;
+
+        exitCode.Should().Be(0);
+        output.Should().Contain("DevSweep");
+    }
+
+    [Test]
+    public async Task ExitCleanlyWhenHelpRequested()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("--help", cts.Token);
+
+        result.ExitCode.Should().Be(0);
+    }
+
+    [Test]
+    public async Task DisplayVersionWhenVersionSubcommandUsed()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("version", cts.Token);
+
+        var exitCode = result.ExitCode;
+        var output = result.StandardOutput;
+
+        exitCode.Should().Be(0);
+        output.Should().Contain("DevSweep");
+    }
+
+    [Test]
+    public async Task ExitCleanlyWhenNoArgumentsProvided()
+    {
+        using var cts = new CancellationTokenSource(LongTestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("--force --dry-run --output plain", cts.Token);
+
+        var exitCode = result.ExitCode;
+        var output = result.StandardOutput;
+
+        exitCode.Should().Be(0);
+        output.Should().Contain("DevSweep");
+    }
+
+    [Test]
+    public async Task RunFullInteractiveFlowWithForceFlag()
+    {
+        using var cts = new CancellationTokenSource(LongTestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("--force --dry-run --output plain", cts.Token);
+
+        var exitCode = result.ExitCode;
+        var output = result.StandardOutput;
+
+        exitCode.Should().Be(0);
+        output.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public async Task FailWhenAnalyzeHasNoModulesAndNoAllFlag()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("analyze", cts.Token);
+
+        result.ExitCode.Should().Be(1);
+    }
+
+    [Test]
+    public async Task AnalyzeAllModulesWithoutCrashing()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("analyze --all", cts.Token);
+
+        result.ExitCode.Should().Be(0);
+    }
+
+    [Test]
+    public async Task FailWhenCleanHasNoModulesAndNoAllFlag()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("clean", cts.Token);
+
+        result.ExitCode.Should().Be(1);
+    }
+
+    [Test]
+    public async Task NotCrashWhenCleanRunsWithDryRunAndForce()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("clean --all --dry-run --force", cts.Token);
+
+        var stderr = result.StandardError;
+
+        stderr.Should().NotContain("Unhandled exception");
+    }
+
+    [Test]
+    public async Task FailWhenInvalidSubcommandProvided()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("nonexistent-command", cts.Token);
+
+        result.ExitCode.Should().NotBe(0);
+    }
+
+    [Test]
+    public async Task FailWhenInvalidModuleNameProvided()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("analyze invalidmodule", cts.Token);
+
+        result.ExitCode.Should().Be(1);
+    }
+
+    [Test]
+    public async Task ProduceOutputWhenJsonFormatRequested()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("analyze --all --output json", cts.Token);
+
+        var exitCode = result.ExitCode;
+        var output = result.StandardOutput;
+
+        exitCode.Should().Be(0);
+        output.Should().NotBeEmpty();
+    }
+
+    [Test]
+    public async Task AcceptMultipleModuleNames()
+    {
+        using var cts = new CancellationTokenSource(TestTimeout);
+
+        var result = await CliProcessRunner.RunAsync("analyze jetbrains docker", cts.Token);
+
+        result.ExitCode.Should().Be(0);
+    }
+}


### PR DESCRIPTION
Closes #42

## Summary

Implements Phase 6 E2E smoke tests and related CLI improvements needed to support them.

## Changes

### feat: `--dry-run` flag in `clean` subcommand
- Added `--dry-run` / `-d` option to `CleanCommand`
- When enabled, runs `IAnalyzeUseCase` instead of `ICleanupUseCase` — no files are deleted
- Tests cover: dry-run invokes analyze, cleanup not called, failure path

### feat: Interactive mode in root command
- `RootCommand` now shows a banner and prompts module selection when invoked with no subcommand
- Runs analysis on selected modules; if `--dry-run` exits after analysis
- Delegates to `IModuleSelector`, `IAnalyzeUseCase`, `ICleanupUseCase`
- Tests cover: full happy path, dry-run stop, no modules selected, analyze/cleanup failure

### test: CLI E2E smoke tests
- `CliProcessRunner` — helper that spawns the published AOT binary as a child process
- `SmokeTestsShould` — verifies `--help`, `--version`, `clean --dry-run`, exit codes and output

## Test results

```
total: 569 | passed: 569 | failed: 0 | skipped: 0
```